### PR TITLE
Update @stablelib/utf8 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -897,9 +897,9 @@
             }
         },
         "@stablelib/utf8": {
-            "version": "1.0.0",
-            "resolved": "https://repository.mark43.io/api/npm/npm-all/@stablelib/utf8/-/utf8-1.0.0.tgz",
-            "integrity": "sha1-fAwDm20VTaUDJgA+qSd33cj12yw="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.2.tgz",
+            "integrity": "sha512-sDL1aB2U8FIpj7SjQJMxbOFIFkKvDKQGPHSrYejHZhtLNSK3qHe6ZIfa0woWkOiaJsdYslFzrc0VWXJZHmSIQQ=="
         },
         "@types/babel__core": {
             "version": "7.1.9",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/mark43/dexie-encrypted.git"
     },
     "dependencies": {
-        "@stablelib/utf8": "1.0.0",
+        "@stablelib/utf8": "1.0.2",
         "tweetnacl": "1.0.3",
         "typeson": "5.18.2",
         "typeson-registry": "1.0.0-alpha.38"


### PR DESCRIPTION
Hi,

This PR updates the version of @stablelib/utf8 to 1.0.2 in the package.json file.

Reason for Update:

- The current version of @stablelib/utf8 used by dexie-encrypted has an issue with handling certain UTF-8 encoded strings, particularly those containing surrogate pairs like emojis, which can cause errors such as "utf-8: invalid string". I found this issue while I was investigating a similar case for my company and I discovered it stemmed from this dependency.

Here is the issue from @stablelib/utf8 with the proper fix included in 1.0.2 for more information:
https://github.com/StableLib/stablelib/issues/66